### PR TITLE
Added serial communication capabilities

### DIFF
--- a/pylablib/aux_libs/devices/IMAQ.py
+++ b/pylablib/aux_libs/devices/IMAQ.py
@@ -163,7 +163,7 @@ class IMAQCamera(interface.IDevice):
         Return tuple ``(hstart, hend, vstart, vend)``.
         """
         t,l,h,w=lib.imgSessionGetROI(self.sid)
-        return l,t,l+w,t+h
+        return l,l+w,t,t+h
     def set_roi(self, hstart=0, hend=None, vstart=0, vend=None):
         """
         Setup camera ROI.
@@ -473,7 +473,7 @@ class IMAQCamera(interface.IDevice):
     def _get_buffer_size(self):
         bpp=self._get_buffer_bpp()
         roi=self.get_roi()
-        w,h=roi[2]-roi[0],roi[3]-roi[1]
+        w,h=roi[1]-roi[0],roi[3]-roi[2]
         return w*h*bpp
     def _parse_buffer(self, buffer, dim=None, bpp=None, nframes=1):
         r,c=dim or self._get_data_dimensions_rc()

--- a/pylablib/aux_libs/devices/IMAQ.py
+++ b/pylablib/aux_libs/devices/IMAQ.py
@@ -665,6 +665,8 @@ class IMAQCamera(interface.IDevice):
         else:
             sid = self.sid
             retval = lib.imgSessionSerialRead(sid, timeout)
+            retval = retval[0].decode()
+            retval = retval.replace(eol, '\n')
 
         return retval
 


### PR DESCRIPTION
CameraLink - cameras allow communication via the serial interface. However, on National Instrument frame grabbers this serial port is not exposed to windows. You need to use the IMAQ interface to the serial port. I've implemented the two basic functions to write and read data to/from the serial port. Tested with the PCI 1430 frame grabber.