### PR TITLE
Thorlabs cam sensor type: monochrome or bayer color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea/*

--- a/pylablib/devices/Thorlabs/TLCamera.py
+++ b/pylablib/devices/Thorlabs/TLCamera.py
@@ -114,11 +114,13 @@ class ThorlabsTLCamera(camera.IBinROICamera, camera.IExposureCamera):
 
         Return tuple ``(model, name, serial_number, firmware_version)``.
         """
-        model=py3.as_str(lib.tl_camera_get_model(self.handle))
-        name=py3.as_str(lib.tl_camera_get_name(self.handle))
-        serial_number=py3.as_str(lib.tl_camera_get_serial_number(self.handle))
-        firmware_version=py3.as_str(lib.tl_camera_get_firmware_version(self.handle))
-        return TDeviceInfo(model,name,serial_number,firmware_version)
+        model = py3.as_str(lib.tl_camera_get_model(self.handle))
+        name = py3.as_str(lib.tl_camera_get_name(self.handle))
+        serial_number = py3.as_str(lib.tl_camera_get_serial_number(self.handle))
+        firmware_version = py3.as_str(lib.tl_camera_get_firmware_version(self.handle))
+        sensor_type = tl_camera_sdk_defs.TL_CAMERA_SENSOR_TYPE(
+            lib.tl_camera_get_camera_sensor_type(self.handle)).name.lstrip('TL_CAMERA_SENSOR_TYPE')
+        return TDeviceInfo(model, name, serial_number, firmware_version, sensor_type)
 
     # ### Acquisition controls ###
     class RingBuffer:

--- a/pylablib/devices/Thorlabs/TLCamera.py
+++ b/pylablib/devices/Thorlabs/TLCamera.py
@@ -29,7 +29,6 @@ class LibraryController(load_lib.LibraryController):
 libctl=LibraryController(lib)
 
 
-
 def list_cameras():
     """List connected TLCamera cameras"""
     with libctl.temp_open():
@@ -38,15 +37,18 @@ def list_cameras():
         except ThorlabsTLCameraError:
             return []
 
+
 def get_cameras_number():
     """Get number of connected TLCamera cameras"""
     return len(list_cameras())
 
 
+TDeviceInfo = collections.namedtuple("TDeviceInfo",
+                                     ["model", "name", "serial_number", "firmware_version", "sensor_type"])
+
+TFrameInfo = collections.namedtuple("TFrameInfo", ["frame_index", "framestamp", "pixelclock", "pixeltype", "offset"])
 
 
-TDeviceInfo=collections.namedtuple("TDeviceInfo",["model","name","serial_number","firmware_version"])
-TFrameInfo=collections.namedtuple("TFrameInfo",["frame_index","framestamp","pixelclock","pixeltype","offset"])
 class ThorlabsTLCamera(camera.IBinROICamera, camera.IExposureCamera):
     """
     Thorlabs TSI camera.


### PR DESCRIPTION
This PR allows to query and add the sensor type to the device info query. This is mandatory because otherwise there is no possibility to check if the camera is monochrome or bayer type color. 

In case of bayer color, the newest frame is actually a raw bayer image and a demosaicification is needed to get back the RGB (or even monochrome) image output. I'm using for this the cvtColor function from OpenCV.

The change here is minimal as only in the returned device info. Could you please accept this PR, I really need this info!

Thanks