### PR TITLE
Fixed bug in reboot method

### DIFF
--- a/pylablib/devices/Toptica/ibeam.py
+++ b/pylablib/devices/Toptica/ibeam.py
@@ -97,7 +97,7 @@ class TopticaIBeam(comm_backend.ICommBackendWrapper):
     
     def reboot(self):
         """Reboot the laser system"""
-        self.query("reset system",reply=False)
+        self.query("reset system",reply=False, multiline=True)
     
     def get_device_info(self):
         """Get the device info of the laser system: ``(serial, version)``"""


### PR DESCRIPTION
The reboot method gives us an error when executed, as it receives multiple lines but only expected one.  If we add the `multiline=True` argument it runs without crashing. We are not sure if this is laser specific behavior as we only have one iBeam smart 515nm laser and can't test it on others.

The error:

```
---------------------------------------------------------------------------
TopticaError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 laser.reboot()

File c:\Users\fulapuser\NOMAD-CAMELS\.desertenv\Lib\site-packages\pylablib\devices\Toptica\ibeam.py:100, in TopticaIBeam.reboot(self)
     98 def reboot(self):
     99     """Reboot the laser system"""
--> 100     self.query("reset system",reply=False,)

File c:\Users\fulapuser\NOMAD-CAMELS\.desertenv\Lib\site-packages\pylablib\devices\Toptica\ibeam.py:92, in TopticaIBeam.query(self, comm, multiline, keep_whitespace, check_error, reply)
     90 for i in range(ntries):
     91     try:
---> 92         return self._do_query(comm,multiline=multiline,keep_whitespace=keep_whitespace,check_error=check_error,reply=reply)
     93     except TopticaError:
     94         if i==ntries-1:

File c:\Users\fulapuser\NOMAD-CAMELS\.desertenv\Lib\site-packages\pylablib\devices\Toptica\ibeam.py:85, in TopticaIBeam._do_query(self, comm, multiline, keep_whitespace, check_error, reply)
     83     return lines
     84 elif len(lines)>1:
---> 85     raise TopticaError("expected single line, but got response {} with {} lines".format("\n".join(lines),len(lines)))
     86 return lines[-1] if lines else None

TopticaError: expected single line, but got response SAVE:FSP
iBEAMsmart pulse option - Ultra Compact Diode Laser
(C)2009, TOPTICA Photonics AG
SerialN: iBEAM-SMART-515-S-A3-17694
PowerUP: 00357h
LaserON: 00062h
LDDinit: PASS
TECloop: LOOP
TECpass: WAITUSER
LaserON: USER
Channel: USER
RFoscON: USER
PWRloop: USER
PDreset: USER
ExtModu: USER
SysBoot: DONE with 16 lines
```