### PR TITLE
bugfix to kinesis.py when using ThorLabs HDR50/M rotation stage with BSC201 controller

### DIFF
--- a/pylablib/devices/Thorlabs/kinesis.py
+++ b/pylablib/devices/Thorlabs/kinesis.py
@@ -196,7 +196,7 @@ class BasicKinesisDevice(comm_backend.ICommBackendWrapper):
 
     _device_SN={   20:"BSC001", 21:"BPC001", 22:"BNT001", 25:"BMS001", 26:"KST101", 27:"KDC101", 28:"KBD101", 29:"KPZ101",
                     30:"BSC002", 31:"BPC002", 33:"BDC101", 35:"BMS002", 37:"MFF10." ,
-                    40:"(BSC101|SSC20.)", 41:"BPC101", 43:"BDC101", 44:"PPC001", 45:"LTS", 48:"MMR", 49:"MLJ",
+                    40:"(BSC101|BSC201|SCC201|SSC20.)", 41:"BPC101", 43:"BDC101", 44:"PPC001", 45:"LTS", 48:"MMR", 49:"MLJ",
                     50:"MST60" , 51:"MPZ601", 52:"MNA601", 55:"K10CR1", 56:"KLS101", 57:"KNA101", 59:"KSG101",
                     60:"0ST001", 63:"ODC001", 64:"TLD001", 65:"TIM001", 67:"TBD001", 68:"KSC101", 69:"KPA101",
                     70:"BSC.03", 71:"BPC.03", 72:"BPS103", 73:"BBD103", 
@@ -1312,7 +1312,7 @@ class KinesisMotor(KinesisDevice):
             return (ssc,ssc*time_conv*2**16,ssc*time_conv**2*2**16),units
         if self._model in ["TST001","MST601"] or self._model.startswith("BSC00") or self._model.startswith("BSC10") or self._model.startswith("MPC"):
             return (ssc,ssc,ssc),units
-        if self._model in ["TST101","KST101","MST602","K10CR1"] or self._model.startswith("BSC20"):
+        if self._model in ["TST101","KST101","MST602","K10CR1"] or self._model.startswith("BSC20") or self._model.startswith("SCC20"):
             vpr=53.68
             avr=204.94E-6
             return (ssc,ssc*vpr,ssc*vpr*avr),units


### PR DESCRIPTION
This is essentially a copy of PR #46 by mnirkko. I have implemented it against the latest version of pylablib and tested it with hardware in my lab. That previous PR seems stale, so perhaps this is easier to merge into the main trunk. 